### PR TITLE
update the REPL intro text to make it clear where the expression goes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -175,7 +175,7 @@
             <div id="repl" role="presentation">
                 <code class="history">
                     <div id="repl-intro-text">
-                        Enter an expression in the input below to evaluate, or a definition (like
+                        Enter an expression in the input field at the bottom to evaluate, or a definition (like
                         <span class="color-blue">x = 1</span>) to use later.
                     </div>
                     <div id="history-text" aria-live="polite"></div>


### PR DESCRIPTION
Something small, but took me a some time before I realized that there is actually an input at the bottom of the page. I tried to click on the text `Enter an expression to evaluate`. Because it's grayed out it looked like the placeholder of an input field. At first I thought the REPL was broken. With a monitor in portrait mode (as per the screenshot below), the actual input is very far at the very bottom so I didn't notice it at first (also grayed out, so not outstanding). I think adding this detail about where the expression goes will help.

<img width="830" height="1456" alt="image" src="https://github.com/user-attachments/assets/ad439a8d-555a-44ae-9077-64ac4f3fb942" />
